### PR TITLE
Add potion management UI

### DIFF
--- a/Form1.Designer.cs
+++ b/Form1.Designer.cs
@@ -1,16 +1,21 @@
-﻿namespace PotionApp
+namespace PotionApp
 {
     partial class Form1
     {
-        /// <summary>
-        ///  Required designer variable.
-        /// </summary>
         private System.ComponentModel.IContainer components = null;
+        private System.Windows.Forms.TabControl tabControl1;
+        private System.Windows.Forms.TabPage tabRecipes;
+        private System.Windows.Forms.TabPage tabQueue;
+        private System.Windows.Forms.TabPage tabInventory;
+        private System.Windows.Forms.ListBox listRecipes;
+        private System.Windows.Forms.ListBox listQueue;
+        private System.Windows.Forms.ListBox listInventory;
+        private System.Windows.Forms.Button btnAdd;
+        private System.Windows.Forms.Button btnEdit;
+        private System.Windows.Forms.Button btnRemove;
+        private System.Windows.Forms.Button btnQueue;
+        private System.Windows.Forms.Button btnBrew;
 
-        /// <summary>
-        ///  Clean up any resources being used.
-        /// </summary>
-        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
         protected override void Dispose(bool disposing)
         {
             if (disposing && (components != null))
@@ -20,20 +25,155 @@
             base.Dispose(disposing);
         }
 
-        #region Windows Form Designer generated code
-
-        /// <summary>
-        ///  Required method for Designer support - do not modify
-        ///  the contents of this method with the code editor.
-        /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(800, 450);
-            this.Text = "Form1";
+            tabControl1 = new System.Windows.Forms.TabControl();
+            tabRecipes = new System.Windows.Forms.TabPage();
+            tabQueue = new System.Windows.Forms.TabPage();
+            tabInventory = new System.Windows.Forms.TabPage();
+            listRecipes = new System.Windows.Forms.ListBox();
+            listQueue = new System.Windows.Forms.ListBox();
+            listInventory = new System.Windows.Forms.ListBox();
+            btnAdd = new System.Windows.Forms.Button();
+            btnEdit = new System.Windows.Forms.Button();
+            btnRemove = new System.Windows.Forms.Button();
+            btnQueue = new System.Windows.Forms.Button();
+            btnBrew = new System.Windows.Forms.Button();
+            tabControl1.SuspendLayout();
+            tabRecipes.SuspendLayout();
+            tabQueue.SuspendLayout();
+            tabInventory.SuspendLayout();
+            SuspendLayout();
+            //
+            // tabControl1
+            //
+            tabControl1.Controls.Add(tabRecipes);
+            tabControl1.Controls.Add(tabQueue);
+            tabControl1.Controls.Add(tabInventory);
+            tabControl1.Dock = System.Windows.Forms.DockStyle.Fill;
+            tabControl1.Location = new System.Drawing.Point(0, 0);
+            tabControl1.Name = "tabControl1";
+            tabControl1.SelectedIndex = 0;
+            tabControl1.Size = new System.Drawing.Size(584, 361);
+            //
+            // tabRecipes
+            //
+            tabRecipes.Controls.Add(listRecipes);
+            tabRecipes.Controls.Add(btnAdd);
+            tabRecipes.Controls.Add(btnEdit);
+            tabRecipes.Controls.Add(btnRemove);
+            tabRecipes.Controls.Add(btnQueue);
+            tabRecipes.Location = new System.Drawing.Point(4, 24);
+            tabRecipes.Name = "tabRecipes";
+            tabRecipes.Padding = new System.Windows.Forms.Padding(3);
+            tabRecipes.Size = new System.Drawing.Size(576, 333);
+            tabRecipes.Text = "Recipes";
+            tabRecipes.UseVisualStyleBackColor = true;
+            //
+            // listRecipes
+            //
+            listRecipes.FormattingEnabled = true;
+            listRecipes.ItemHeight = 15;
+            listRecipes.Location = new System.Drawing.Point(6, 6);
+            listRecipes.Name = "listRecipes";
+            listRecipes.Size = new System.Drawing.Size(400, 319);
+            //
+            // btnAdd
+            //
+            btnAdd.Location = new System.Drawing.Point(412, 6);
+            btnAdd.Name = "btnAdd";
+            btnAdd.Size = new System.Drawing.Size(75, 23);
+            btnAdd.Text = "Add";
+            btnAdd.UseVisualStyleBackColor = true;
+            btnAdd.Click += btnAdd_Click;
+            //
+            // btnEdit
+            //
+            btnEdit.Location = new System.Drawing.Point(412, 35);
+            btnEdit.Name = "btnEdit";
+            btnEdit.Size = new System.Drawing.Size(75, 23);
+            btnEdit.Text = "Edit";
+            btnEdit.UseVisualStyleBackColor = true;
+            btnEdit.Click += btnEdit_Click;
+            //
+            // btnRemove
+            //
+            btnRemove.Location = new System.Drawing.Point(412, 64);
+            btnRemove.Name = "btnRemove";
+            btnRemove.Size = new System.Drawing.Size(75, 23);
+            btnRemove.Text = "Remove";
+            btnRemove.UseVisualStyleBackColor = true;
+            btnRemove.Click += btnRemove_Click;
+            //
+            // btnQueue
+            //
+            btnQueue.Location = new System.Drawing.Point(412, 93);
+            btnQueue.Name = "btnQueue";
+            btnQueue.Size = new System.Drawing.Size(75, 23);
+            btnQueue.Text = "Queue";
+            btnQueue.UseVisualStyleBackColor = true;
+            btnQueue.Click += btnQueue_Click;
+            //
+            // tabQueue
+            //
+            tabQueue.Controls.Add(listQueue);
+            tabQueue.Controls.Add(btnBrew);
+            tabQueue.Location = new System.Drawing.Point(4, 24);
+            tabQueue.Name = "tabQueue";
+            tabQueue.Padding = new System.Windows.Forms.Padding(3);
+            tabQueue.Size = new System.Drawing.Size(576, 333);
+            tabQueue.Text = "Queue";
+            tabQueue.UseVisualStyleBackColor = true;
+            //
+            // listQueue
+            //
+            listQueue.FormattingEnabled = true;
+            listQueue.ItemHeight = 15;
+            listQueue.Location = new System.Drawing.Point(6, 6);
+            listQueue.Name = "listQueue";
+            listQueue.Size = new System.Drawing.Size(400, 319);
+            //
+            // btnBrew
+            //
+            btnBrew.Location = new System.Drawing.Point(412, 6);
+            btnBrew.Name = "btnBrew";
+            btnBrew.Size = new System.Drawing.Size(75, 23);
+            btnBrew.Text = "Brew Next";
+            btnBrew.UseVisualStyleBackColor = true;
+            btnBrew.Click += btnBrew_Click;
+            //
+            // tabInventory
+            //
+            tabInventory.Controls.Add(listInventory);
+            tabInventory.Location = new System.Drawing.Point(4, 24);
+            tabInventory.Name = "tabInventory";
+            tabInventory.Padding = new System.Windows.Forms.Padding(3);
+            tabInventory.Size = new System.Drawing.Size(576, 333);
+            tabInventory.Text = "Inventory";
+            tabInventory.UseVisualStyleBackColor = true;
+            //
+            // listInventory
+            //
+            listInventory.FormattingEnabled = true;
+            listInventory.ItemHeight = 15;
+            listInventory.Location = new System.Drawing.Point(6, 6);
+            listInventory.Name = "listInventory";
+            listInventory.Size = new System.Drawing.Size(400, 319);
+            listInventory.DoubleClick += listInventory_DoubleClick;
+            //
+            // Form1
+            //
+            AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            ClientSize = new System.Drawing.Size(584, 361);
+            Controls.Add(tabControl1);
+            Name = "Form1";
+            Text = "Potion Manager";
+            tabControl1.ResumeLayout(false);
+            tabRecipes.ResumeLayout(false);
+            tabQueue.ResumeLayout(false);
+            tabInventory.ResumeLayout(false);
+            ResumeLayout(false);
         }
-
-        #endregion
     }
 }

--- a/Form1.cs
+++ b/Form1.cs
@@ -1,10 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.Windows.Forms;
+
 namespace PotionApp
 {
     public partial class Form1 : Form
     {
+        private readonly List<Recipe> recipes = new();
+        private readonly Queue<Recipe> brewQueue = new();
+        private readonly Dictionary<string, int> inventory = new();
+
         public Form1()
         {
             InitializeComponent();
+            RefreshAll();
+        }
+
+        private void btnAdd_Click(object sender, EventArgs e)
+        {
+            using var frm = new RecipeForm();
+            if (frm.ShowDialog(this) == DialogResult.OK)
+            {
+                recipes.Add(frm.Recipe);
+                RefreshRecipes();
+            }
+        }
+
+        private Recipe? SelectedRecipe => listRecipes.SelectedItem as Recipe;
+
+        private void btnEdit_Click(object sender, EventArgs e)
+        {
+            if (SelectedRecipe == null) return;
+            using var frm = new RecipeForm(SelectedRecipe);
+            if (frm.ShowDialog(this) == DialogResult.OK)
+            {
+                RefreshRecipes();
+            }
+        }
+
+        private void btnRemove_Click(object sender, EventArgs e)
+        {
+            if (SelectedRecipe == null) return;
+            recipes.Remove(SelectedRecipe);
+            RefreshRecipes();
+        }
+
+        private void btnQueue_Click(object sender, EventArgs e)
+        {
+            if (SelectedRecipe == null) return;
+            brewQueue.Enqueue(SelectedRecipe);
+            RefreshQueue();
+        }
+
+        private void btnBrew_Click(object sender, EventArgs e)
+        {
+            if (brewQueue.Count == 0) return;
+            var rec = brewQueue.Dequeue();
+            if (!inventory.ContainsKey(rec.Name)) inventory[rec.Name] = 0;
+            inventory[rec.Name]++;
+            RefreshQueue();
+            RefreshInventory();
+        }
+
+        private void listInventory_DoubleClick(object sender, EventArgs e)
+        {
+            if (listInventory.SelectedItem is not string item) return;
+            var parts = item.Split(':');
+            if (parts.Length == 2)
+            {
+                var name = parts[0].Trim();
+                if (inventory.TryGetValue(name, out int count) && count > 0)
+                {
+                    inventory[name] = count - 1;
+                    if (inventory[name] <= 0) inventory.Remove(name);
+                    RefreshInventory();
+                }
+            }
+        }
+
+        private void RefreshRecipes()
+        {
+            listRecipes.DataSource = null;
+            listRecipes.DataSource = recipes;
+        }
+
+        private void RefreshQueue()
+        {
+            listQueue.DataSource = null;
+            listQueue.DataSource = brewQueue.ToArray();
+        }
+
+        private void RefreshInventory()
+        {
+            listInventory.DataSource = null;
+            var items = new List<string>();
+            foreach (var kv in inventory)
+            {
+                items.Add($"{kv.Key}: {kv.Value}");
+            }
+            listInventory.DataSource = items;
+        }
+
+        private void RefreshAll()
+        {
+            RefreshRecipes();
+            RefreshQueue();
+            RefreshInventory();
         }
     }
 }

--- a/Recipe.cs
+++ b/Recipe.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace PotionApp
+{
+    public class Recipe
+    {
+        public string Name { get; set; } = "";
+        public int Animal { get; set; }
+        public int Berry { get; set; }
+        public int Fungi { get; set; }
+        public int Herb { get; set; }
+        public int Magic { get; set; }
+        public int Mineral { get; set; }
+        public int Root { get; set; }
+        public int Solution { get; set; }
+
+        public int TotalIngredients => Animal + Berry + Fungi + Herb + Magic + Mineral + Root + Solution;
+
+        public override string ToString()
+        {
+            return $"{Name} (Total: {TotalIngredients})";
+        }
+    }
+}

--- a/RecipeForm.Designer.cs
+++ b/RecipeForm.Designer.cs
@@ -1,0 +1,110 @@
+using System.Windows.Forms;
+
+namespace PotionApp
+{
+    partial class RecipeForm
+    {
+        private System.ComponentModel.IContainer components = null;
+        private TextBox txtName;
+        private NumericUpDown numAnimal;
+        private NumericUpDown numBerry;
+        private NumericUpDown numFungi;
+        private NumericUpDown numHerb;
+        private NumericUpDown numMagic;
+        private NumericUpDown numMineral;
+        private NumericUpDown numRoot;
+        private NumericUpDown numSolution;
+        private Button btnOk;
+        private Button btnCancel;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        private void InitializeComponent()
+        {
+            txtName = new TextBox();
+            numAnimal = new NumericUpDown();
+            numBerry = new NumericUpDown();
+            numFungi = new NumericUpDown();
+            numHerb = new NumericUpDown();
+            numMagic = new NumericUpDown();
+            numMineral = new NumericUpDown();
+            numRoot = new NumericUpDown();
+            numSolution = new NumericUpDown();
+            btnOk = new Button();
+            btnCancel = new Button();
+            SuspendLayout();
+            //
+            // txtName
+            //
+            txtName.Location = new System.Drawing.Point(12, 12);
+            txtName.Name = "txtName";
+            txtName.Size = new System.Drawing.Size(200, 23);
+            txtName.TabIndex = 0;
+            txtName.PlaceholderText = "Recipe Name";
+            //
+            // numeric controls
+            //
+            int top = 50;
+            NumericUpDown[] nums = { numAnimal, numBerry, numFungi, numHerb, numMagic, numMineral, numRoot, numSolution };
+            string[] labels = { "Animal", "Berry", "Fungi", "Herb", "Magic", "Mineral", "Root", "Solution" };
+            for (int i = 0; i < nums.Length; i++)
+            {
+                Label lbl = new Label();
+                lbl.Text = labels[i];
+                lbl.Location = new System.Drawing.Point(12, top + i * 30);
+                lbl.AutoSize = true;
+                Controls.Add(lbl);
+
+                nums[i].Location = new System.Drawing.Point(80, top + i * 30 - 3);
+                nums[i].Name = "num" + labels[i];
+                nums[i].Maximum = 1000;
+                Controls.Add(nums[i]);
+            }
+            //
+            // btnOk
+            //
+            btnOk.Location = new System.Drawing.Point(56, top + nums.Length * 30);
+            btnOk.Name = "btnOk";
+            btnOk.Size = new System.Drawing.Size(75, 23);
+            btnOk.TabIndex = 1;
+            btnOk.Text = "OK";
+            btnOk.UseVisualStyleBackColor = true;
+            btnOk.Click += btnOk_Click;
+            //
+            // btnCancel
+            //
+            btnCancel.DialogResult = DialogResult.Cancel;
+            btnCancel.Location = new System.Drawing.Point(137, top + nums.Length * 30);
+            btnCancel.Name = "btnCancel";
+            btnCancel.Size = new System.Drawing.Size(75, 23);
+            btnCancel.TabIndex = 2;
+            btnCancel.Text = "Cancel";
+            btnCancel.UseVisualStyleBackColor = true;
+            //
+            // RecipeForm
+            //
+            AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
+            ClientSize = new System.Drawing.Size(224, top + nums.Length * 30 + 40);
+            Controls.Add(txtName);
+            Controls.Add(btnOk);
+            Controls.Add(btnCancel);
+            FormBorderStyle = FormBorderStyle.FixedDialog;
+            MaximizeBox = false;
+            MinimizeBox = false;
+            AcceptButton = btnOk;
+            CancelButton = btnCancel;
+            Name = "RecipeForm";
+            Text = "Recipe";
+            ResumeLayout(false);
+            PerformLayout();
+        }
+    }
+}

--- a/RecipeForm.cs
+++ b/RecipeForm.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Windows.Forms;
+
+namespace PotionApp
+{
+    public partial class RecipeForm : Form
+    {
+        public Recipe Recipe { get; private set; }
+
+        public RecipeForm(Recipe? recipe = null)
+        {
+            InitializeComponent();
+            if (recipe != null)
+            {
+                Recipe = recipe;
+                txtName.Text = recipe.Name;
+                numAnimal.Value = recipe.Animal;
+                numBerry.Value = recipe.Berry;
+                numFungi.Value = recipe.Fungi;
+                numHerb.Value = recipe.Herb;
+                numMagic.Value = recipe.Magic;
+                numMineral.Value = recipe.Mineral;
+                numRoot.Value = recipe.Root;
+                numSolution.Value = recipe.Solution;
+            }
+            else
+            {
+                Recipe = new Recipe();
+            }
+        }
+
+        private void btnOk_Click(object sender, EventArgs e)
+        {
+            Recipe.Name = txtName.Text.Trim();
+            Recipe.Animal = (int)numAnimal.Value;
+            Recipe.Berry = (int)numBerry.Value;
+            Recipe.Fungi = (int)numFungi.Value;
+            Recipe.Herb = (int)numHerb.Value;
+            Recipe.Magic = (int)numMagic.Value;
+            Recipe.Mineral = (int)numMineral.Value;
+            Recipe.Root = (int)numRoot.Value;
+            Recipe.Solution = (int)numSolution.Value;
+            DialogResult = DialogResult.OK;
+            Close();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `Recipe` class
- add recipe editor form
- build UI for managing recipes, brewing queue, and inventory
- implement brewing and inventory logic

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68461066f05883298533553970af53ee