### PR TITLE
Change save directory to potionkit2

### DIFF
--- a/Form1.cs
+++ b/Form1.cs
@@ -12,7 +12,7 @@ namespace PotionApp
         private readonly Queue<Recipe> brewQueue = new();
         private readonly Dictionary<string, int> inventory = new();
 
-        private readonly string dataDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "PotionKit");
+        private readonly string dataDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "potionkit2");
         private string IngredientsPath => Path.Combine(dataDir, "ingredients.json");
         private string RecipesPath => Path.Combine(dataDir, "recipes.json");
         private string InventoryPath => Path.Combine(dataDir, "inventory.json");


### PR DESCRIPTION
## Summary
- adjust the data directory path to save under `Documents/potionkit2`

## Testing
- `dotnet build PotionApp.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_684642d196448329911463c201225f65