### PR TITLE
Add column headers and special totals

### DIFF
--- a/Form1.Designer.cs
+++ b/Form1.Designer.cs
@@ -23,6 +23,8 @@ namespace PotionApp
         private System.Windows.Forms.NumericUpDown numRoot;
         private System.Windows.Forms.NumericUpDown numSolution;
         private System.Windows.Forms.RichTextBox rtbTotals;
+        private System.Windows.Forms.Label lblRecipeColumns;
+        private System.Windows.Forms.Label lblQueueColumns;
 
         protected override void Dispose(bool disposing)
         {
@@ -82,6 +84,7 @@ namespace PotionApp
             //
             // tabRecipes
             //
+            tabRecipes.Controls.Add(lblRecipeColumns);
             tabRecipes.Controls.Add(listRecipes);
             tabRecipes.Controls.Add(btnAdd);
             tabRecipes.Location = new System.Drawing.Point(4, 24);
@@ -95,10 +98,18 @@ namespace PotionApp
             //
             listRecipes.FormattingEnabled = true;
             listRecipes.ItemHeight = 15;
-            listRecipes.Location = new System.Drawing.Point(6, 6);
+            listRecipes.Location = new System.Drawing.Point(6, 26);
             listRecipes.Name = "listRecipes";
-            listRecipes.Size = new System.Drawing.Size(400, 319);
+            listRecipes.Size = new System.Drawing.Size(400, 299);
             listRecipes.DoubleClick += listRecipes_DoubleClick;
+            //
+            // lblRecipeColumns
+            //
+            lblRecipeColumns.AutoSize = true;
+            lblRecipeColumns.Location = new System.Drawing.Point(6, 6);
+            lblRecipeColumns.Name = "lblRecipeColumns";
+            lblRecipeColumns.Size = new System.Drawing.Size(0, 15);
+            lblRecipeColumns.TabIndex = 3;
             //
             // btnAdd
             //
@@ -113,6 +124,7 @@ namespace PotionApp
             //
             tabBrew.Controls.Add(comboRecipes);
             tabBrew.Controls.Add(btnAddQueue);
+            tabBrew.Controls.Add(lblQueueColumns);
             tabBrew.Controls.Add(listQueue);
             tabBrew.Controls.Add(btnBrew);
             tabBrew.Controls.Add(rtbTotals);
@@ -154,6 +166,14 @@ namespace PotionApp
             listQueue.Location = new System.Drawing.Point(6, 199);
             listQueue.Name = "listQueue";
             listQueue.Size = new System.Drawing.Size(400, 128);
+            //
+            // lblQueueColumns
+            //
+            lblQueueColumns.AutoSize = true;
+            lblQueueColumns.Location = new System.Drawing.Point(6, 180);
+            lblQueueColumns.Name = "lblQueueColumns";
+            lblQueueColumns.Size = new System.Drawing.Size(0, 15);
+            lblQueueColumns.TabIndex = 9;
             //
             // btnBrew
             //

--- a/Form1.cs
+++ b/Form1.cs
@@ -23,6 +23,8 @@ namespace PotionApp
         {
             InitializeComponent();
             SetupIngredientControls();
+            lblRecipeColumns.Text = Recipe.Header;
+            lblQueueColumns.Text = Recipe.Header;
             LoadData();
             RefreshAll();
             FormClosing += Form1_FormClosing;
@@ -198,6 +200,7 @@ namespace PotionApp
         {
             if (ingredientControls.Length == 0) return;
             int[] totals = new int[ingredientControls.Length];
+            var specialCounts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
             foreach (var r in brewQueue)
             {
                 totals[0] += r.Animal;
@@ -208,6 +211,16 @@ namespace PotionApp
                 totals[5] += r.Mineral;
                 totals[6] += r.Root;
                 totals[7] += r.Solution;
+                if (!string.IsNullOrWhiteSpace(r.Special))
+                {
+                    foreach (var sp in r.Special.Split(',', StringSplitOptions.RemoveEmptyEntries))
+                    {
+                        var name = sp.Trim();
+                        if (name.Length == 0) continue;
+                        if (!specialCounts.ContainsKey(name)) specialCounts[name] = 0;
+                        specialCounts[name]++;
+                    }
+                }
             }
 
             rtbTotals.Clear();
@@ -221,6 +234,14 @@ namespace PotionApp
                 rtbTotals.AppendText(remaining.ToString());
                 rtbTotals.SelectionColor = System.Drawing.Color.Black;
                 rtbTotals.AppendText(")\n");
+            }
+            if (specialCounts.Count > 0)
+            {
+                rtbTotals.AppendText("\nSpecial Ingredients:\n");
+                foreach (var kv in specialCounts)
+                {
+                    rtbTotals.AppendText($"{kv.Key}: {kv.Value}\n");
+                }
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # PotionApp
+
+PotionApp is a simple Windows Forms application for managing potion recipes and brewing queues.
+
+## Features
+
+- Add and edit recipes with ingredient counts and special items.
+- Queue up multiple recipes for brewing and track required ingredients.
+- View inventory of brewed potions.
+- Totals panel shows how many ingredients are needed and highlights shortages.
+- Column headers now label each ingredient in the recipe and queue lists.
+- Special ingredients are summarized in the totals panel.
+

--- a/Recipe.cs
+++ b/Recipe.cs
@@ -15,6 +15,10 @@ namespace PotionApp
         public int Solution { get; set; }
         public string Special { get; set; } = "";
 
+        public static readonly string Header = string.Format(
+            "{0,-15} {1,3} {2,3} {3,3} {4,3} {5,3} {6,3} {7,3} {8,3} {9}",
+            "Name", "Ani", "Ber", "Fun", "Her", "Mag", "Min", "Roo", "Sol", "Special");
+
         public int TotalIngredients => Animal + Berry + Fungi + Herb + Magic + Mineral + Root + Solution;
 
         public override string ToString()


### PR DESCRIPTION
## Summary
- label ingredient columns for recipes and brew queue
- show header text for columns
- track special ingredients in totals panel
- document features in README

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68468fae39848329afcf23ec6e0809eb