### PR TITLE
Add manual potion entry and highlight unknown names

### DIFF
--- a/Form1.Designer.cs
+++ b/Form1.Designer.cs
@@ -14,6 +14,9 @@ namespace PotionApp
         private System.Windows.Forms.ListBox listQueue;
         private System.Windows.Forms.Button btnBrew;
         private System.Windows.Forms.ListBox listInventory;
+        private System.Windows.Forms.TextBox txtInventoryName;
+        private System.Windows.Forms.NumericUpDown numInventoryCount;
+        private System.Windows.Forms.Button btnInventoryAdd;
         private System.Windows.Forms.NumericUpDown numAnimal;
         private System.Windows.Forms.NumericUpDown numBerry;
         private System.Windows.Forms.NumericUpDown numFungi;
@@ -42,6 +45,9 @@ namespace PotionApp
             listRecipes = new System.Windows.Forms.ListBox();
             listQueue = new System.Windows.Forms.ListBox();
             listInventory = new System.Windows.Forms.ListBox();
+            txtInventoryName = new System.Windows.Forms.TextBox();
+            numInventoryCount = new System.Windows.Forms.NumericUpDown();
+            btnInventoryAdd = new System.Windows.Forms.Button();
             btnAdd = new System.Windows.Forms.Button();
             btnAddQueue = new System.Windows.Forms.Button();
             btnBrew = new System.Windows.Forms.Button();
@@ -67,6 +73,7 @@ namespace PotionApp
             ((System.ComponentModel.ISupportInitialize)(numMineral)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(numRoot)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(numSolution)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(numInventoryCount)).BeginInit();
             SuspendLayout();
             //
             // tabControl1
@@ -175,6 +182,9 @@ namespace PotionApp
             // tabInventory
             //
             tabInventory.Controls.Add(listInventory);
+            tabInventory.Controls.Add(txtInventoryName);
+            tabInventory.Controls.Add(numInventoryCount);
+            tabInventory.Controls.Add(btnInventoryAdd);
             tabInventory.Location = new System.Drawing.Point(4, 24);
             tabInventory.Name = "tabInventory";
             tabInventory.Padding = new System.Windows.Forms.Padding(3);
@@ -189,7 +199,33 @@ namespace PotionApp
             listInventory.Location = new System.Drawing.Point(6, 6);
             listInventory.Name = "listInventory";
             listInventory.Size = new System.Drawing.Size(400, 319);
+            listInventory.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            listInventory.DrawItem += listInventory_DrawItem;
             listInventory.DoubleClick += listInventory_DoubleClick;
+            //
+            // txtInventoryName
+            //
+            txtInventoryName.Location = new System.Drawing.Point(412, 6);
+            txtInventoryName.Name = "txtInventoryName";
+            txtInventoryName.Size = new System.Drawing.Size(150, 23);
+            //
+            // numInventoryCount
+            //
+            numInventoryCount.Location = new System.Drawing.Point(412, 35);
+            numInventoryCount.Maximum = 1000;
+            numInventoryCount.Minimum = 1;
+            numInventoryCount.Name = "numInventoryCount";
+            numInventoryCount.Size = new System.Drawing.Size(60, 23);
+            numInventoryCount.Value = 1;
+            //
+            // btnInventoryAdd
+            //
+            btnInventoryAdd.Location = new System.Drawing.Point(478, 34);
+            btnInventoryAdd.Name = "btnInventoryAdd";
+            btnInventoryAdd.Size = new System.Drawing.Size(84, 23);
+            btnInventoryAdd.Text = "Add";
+            btnInventoryAdd.UseVisualStyleBackColor = true;
+            btnInventoryAdd.Click += btnInventoryAdd_Click;
             //
             // Form1
             //
@@ -211,6 +247,7 @@ namespace PotionApp
             ((System.ComponentModel.ISupportInitialize)(numMineral)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(numRoot)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(numSolution)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(numInventoryCount)).EndInit();
             ResumeLayout(false);
         }
     }

--- a/Form1.cs
+++ b/Form1.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
 using System.Windows.Forms;
 using System.Text.Json;
 using System.IO;
@@ -110,6 +112,30 @@ namespace PotionApp
                     RefreshInventory();
                 }
             }
+        }
+
+        private void btnInventoryAdd_Click(object sender, EventArgs e)
+        {
+            var name = txtInventoryName.Text.Trim();
+            if (string.IsNullOrEmpty(name)) return;
+            int count = (int)numInventoryCount.Value;
+            if (!inventory.ContainsKey(name)) inventory[name] = 0;
+            inventory[name] += count;
+            RefreshInventory();
+        }
+
+        private void listInventory_DrawItem(object? sender, DrawItemEventArgs e)
+        {
+            if (e.Index < 0) return;
+            e.DrawBackground();
+            var item = listInventory.Items[e.Index]?.ToString() ?? string.Empty;
+            var name = item.Split(':')[0].Trim();
+            bool known = recipes.Any(r => r.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+            Color textColor = (e.State & DrawItemState.Selected) == DrawItemState.Selected
+                ? SystemColors.HighlightText
+                : (known ? listInventory.ForeColor : Color.Orange);
+            TextRenderer.DrawText(e.Graphics, item, e.Font, e.Bounds, textColor, TextFormatFlags.Left);
+            e.DrawFocusRectangle();
         }
 
         private void SetupIngredientControls()


### PR DESCRIPTION
## Summary
- allow manual potion entry by adding controls on the Inventory tab
- colour unknown potions in the inventory

## Testing
- `dotnet build PotionApp.csproj -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846900a174883299260243abd5a61f2