### PR TITLE
Fix label initialization in Form1

### DIFF
--- a/Form1.Designer.cs
+++ b/Form1.Designer.cs
@@ -71,6 +71,8 @@ namespace PotionApp
             numBottles = new System.Windows.Forms.NumericUpDown();
             barWater = new System.Windows.Forms.ProgressBar();
             lblWater = new System.Windows.Forms.Label();
+            lblRecipeColumns = new System.Windows.Forms.Label();
+            lblQueueColumns = new System.Windows.Forms.Label();
             btnWaterPlus = new System.Windows.Forms.Button();
             btnWaterMinus = new System.Windows.Forms.Button();
             btnFillWater = new System.Windows.Forms.Button();


### PR DESCRIPTION
## Summary
- instantiate `lblRecipeColumns` and `lblQueueColumns` to avoid `NullReferenceException`

## Testing
- `dotnet build PotionApp.sln -v minimal` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846944d9224832987cf3e55f9fbfdfd