### PR TITLE
Fix water check for brew-all

### DIFF
--- a/Form1.cs
+++ b/Form1.cs
@@ -81,6 +81,12 @@ namespace PotionApp
         private void btnBrew_Click(object sender, EventArgs e)
         {
             if (brewQueue.Count == 0) return;
+            int totalWaterNeeded = brewQueue.Count * 200;
+            if (waterAmount < totalWaterNeeded)
+            {
+                MessageBox.Show("Not enough water", "Cannot Brew", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
             while (brewQueue.Count > 0)
             {
                 var rec = brewQueue.Peek();


### PR DESCRIPTION
## Summary
- ensure Brew All fails if there's not enough water for the entire queue

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846ef1dbbe88329aec078f319eb96f9