### PR TITLE
Add context menu for creating recipes from inventory

### DIFF
--- a/Form1.Designer.cs
+++ b/Form1.Designer.cs
@@ -343,7 +343,7 @@ namespace PotionApp
             txtHelp.ReadOnly = true;
             txtHelp.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
             txtHelp.Size = new System.Drawing.Size(766, 327);
-            txtHelp.Text = "Controls:\r\n\r\nRecipes tab:\r\n - Add new recipes with the Add button.\r\n - Double-click a recipe to edit it.\r\n\r\nBrewing tab:\r\n - Choose a recipe and press Add to queue.\r\n - Double-click a queued item to remove it.\r\n - Brew All consumes ingredients and bottles.\r\n - Use the + and - buttons to adjust ingredient or water amounts. Hold Shift for \u00b15, Ctrl for \u00b110, and both for \u00b1100.\r\n\r\nInventory tab:\r\n - Enter a name and count then click Add.\r\n - Double-click an item to consume one. Unknown potions show in orange.";
+            txtHelp.Text = "Controls:\r\n\r\nRecipes tab:\r\n - Add new recipes with the Add button.\r\n - Double-click a recipe to edit it.\r\n\r\nBrewing tab:\r\n - Choose a recipe and press Add to queue.\r\n - Double-click a queued item to remove it.\r\n - Brew All consumes ingredients and bottles.\r\n - Use the + and - buttons to adjust ingredient or water amounts. Hold Shift for \u00b15, Ctrl for \u00b110, and both for \u00b1100.\r\n\r\nInventory tab:\r\n - Enter a name and count then click Add.\r\n - Double-click an item to consume one.\r\n - Right-click an item to create a recipe with that name.\r\n Unknown potions show in orange.";
             //
             // Form1
             //

--- a/Form1.cs
+++ b/Form1.cs
@@ -15,6 +15,7 @@ namespace PotionApp
         private readonly Dictionary<string, int> inventory = new();
         private readonly string[] ingredientNames = { "Animal", "Berry", "Fungi", "Herb", "Magic", "Mineral", "Root", "Solution", "Bottles" };
         private NumericUpDown[] ingredientControls = Array.Empty<NumericUpDown>();
+        private readonly ContextMenuStrip inventoryMenu = new();
 
         private int waterAmount = 1000;
 
@@ -26,6 +27,9 @@ namespace PotionApp
         public Form1()
         {
             InitializeComponent();
+            inventoryMenu.Items.Add("Add Recipe", null, inventoryAddRecipe_Click);
+            listInventory.ContextMenuStrip = inventoryMenu;
+            listInventory.MouseDown += listInventory_MouseDown;
             SetupIngredientControls();
             lblRecipeColumns.Text = Recipe.Header;
             lblQueueColumns.Text = Recipe.Header;
@@ -209,6 +213,27 @@ namespace PotionApp
                 : (known ? listInventory.ForeColor : Color.Orange);
             TextRenderer.DrawText(e.Graphics, item, e.Font, e.Bounds, textColor, TextFormatFlags.Left);
             e.DrawFocusRectangle();
+        }
+
+        private void listInventory_MouseDown(object? sender, MouseEventArgs e)
+        {
+            if (e.Button == MouseButtons.Right)
+            {
+                int index = listInventory.IndexFromPoint(e.Location);
+                if (index >= 0) listInventory.SelectedIndex = index;
+            }
+        }
+
+        private void inventoryAddRecipe_Click(object? sender, EventArgs e)
+        {
+            if (listInventory.SelectedItem is not string item) return;
+            var name = item.Split(":")[0].Trim();
+            using var frm = new RecipeForm(new Recipe { Name = name });
+            if (frm.ShowDialog(this) == DialogResult.OK)
+            {
+                recipes.Add(frm.Recipe);
+                RefreshRecipes();
+            }
         }
 
         private void SetupIngredientControls()

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ PotionApp is a simple Windows Forms application for managing potion recipes and 
 - Add and edit recipes with ingredient counts and special items.
 - Queue up multiple recipes for brewing and track required ingredients.
 - View inventory of brewed potions.
+- Right-click an inventory item to create a recipe for that potion.
 - Totals panel shows how many ingredients are needed and highlights shortages.
 - Column headers now label each ingredient in the recipe and queue lists.
 - Special ingredients are summarized in the totals panel.


### PR DESCRIPTION
## Summary
- allow right-clicking inventory items to create a recipe with that name
- document new behavior in README and Help tab

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet build --no-restore` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_6846f0c0d8188329b7b194c64fd7e19b