### PR TITLE
Enhance inventory context menu

### DIFF
--- a/Form1.cs
+++ b/Form1.cs
@@ -30,6 +30,9 @@ namespace PotionApp
         {
             InitializeComponent();
             inventoryMenu.Items.Add("Add Recipe", null, inventoryAddRecipe_Click);
+            inventoryMenu.Items.Add("Edit Count", null, inventoryEditCount_Click);
+            inventoryMenu.Items.Add("Rename", null, inventoryRename_Click);
+            inventoryMenu.Items.Add("Add To Queue", null, inventoryAddQueue_Click);
             listInventory.ContextMenuStrip = inventoryMenu;
             listInventory.MouseDown += listInventory_MouseDown;
 
@@ -266,6 +269,59 @@ namespace PotionApp
             {
                 recipes.Add(frm.Recipe);
                 RefreshRecipes();
+            }
+        }
+
+        private void inventoryEditCount_Click(object? sender, EventArgs e)
+        {
+            if (listInventory.SelectedItem is not string item) return;
+            var name = item.Split(":")[0].Trim();
+            if (!inventory.TryGetValue(name, out int count)) return;
+            var input = SimplePrompt.ShowDialog("Enter new amount:", "Edit Count", count.ToString());
+            if (input == null) return;
+            if (int.TryParse(input, out int newCount) && newCount >= 0)
+            {
+                if (newCount == 0)
+                    inventory.Remove(name);
+                else
+                    inventory[name] = newCount;
+                RefreshInventory();
+            }
+            else
+            {
+                MessageBox.Show("Invalid number", "Edit Count", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+
+        private void inventoryRename_Click(object? sender, EventArgs e)
+        {
+            if (listInventory.SelectedItem is not string item) return;
+            var name = item.Split(":")[0].Trim();
+            var input = SimplePrompt.ShowDialog("Enter new name:", "Rename Potion", name);
+            if (input == null) return;
+            var newName = input.Trim();
+            if (newName.Length == 0 || newName.Equals(name, StringComparison.OrdinalIgnoreCase)) return;
+            if (!inventory.TryGetValue(name, out int count)) return;
+            inventory.Remove(name);
+            if (!inventory.ContainsKey(newName))
+                inventory[newName] = 0;
+            inventory[newName] += count;
+            RefreshInventory();
+        }
+
+        private void inventoryAddQueue_Click(object? sender, EventArgs e)
+        {
+            if (listInventory.SelectedItem is not string item) return;
+            var name = item.Split(":")[0].Trim();
+            var rec = recipes.FirstOrDefault(r => r.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+            if (rec != null)
+            {
+                brewQueue.Enqueue(rec);
+                RefreshQueue();
+            }
+            else
+            {
+                MessageBox.Show($"No recipe found for {name}", "Add To Queue", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ PotionApp is a simple Windows Forms application for managing potion recipes and 
 - Queue up multiple recipes for brewing and track required ingredients.
 - View inventory of brewed potions.
 - Right-click an inventory item to create a recipe for that potion.
+- Right-click an inventory item to edit its count, rename it, or quickly add it to the brew queue.
 - Totals panel shows how many ingredients are needed and highlights shortages.
 - Column headers now label each ingredient in the recipe and queue lists.
 - Special ingredients are summarized in the totals panel.

--- a/SimplePrompt.cs
+++ b/SimplePrompt.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace PotionApp
+{
+    public static class SimplePrompt
+    {
+        public static string? ShowDialog(string text, string caption, string defaultValue = "")
+        {
+            using var form = new Form();
+            form.Text = caption;
+            form.FormBorderStyle = FormBorderStyle.FixedDialog;
+            form.StartPosition = FormStartPosition.CenterParent;
+            form.MinimizeBox = false;
+            form.MaximizeBox = false;
+            form.ClientSize = new Size(400, 100);
+
+            var lbl = new Label { AutoSize = true, Text = text, Location = new Point(9, 9) };
+            var tb = new TextBox { Text = defaultValue, Location = new Point(12, 30), Width = 376 };
+            var btnOk = new Button { Text = "OK", DialogResult = DialogResult.OK, Location = new Point(313, 62) };
+            var btnCancel = new Button { Text = "Cancel", DialogResult = DialogResult.Cancel, Location = new Point(232, 62) };
+
+            form.Controls.AddRange(new Control[] { lbl, tb, btnCancel, btnOk });
+            form.AcceptButton = btnOk;
+            form.CancelButton = btnCancel;
+
+            return form.ShowDialog() == DialogResult.OK ? tb.Text : null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add simple prompt helper form
- extend inventory context menu with edit, rename and queue actions
- document new inventory options in README

## Testing
- `dotnet build PotionApp.csproj` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6846fbd2066083299edae4451a8a1842