### PR TITLE
Fix NullReferenceException in InitializeComponent

### DIFF
--- a/Form1.Designer.cs
+++ b/Form1.Designer.cs
@@ -68,6 +68,8 @@ namespace PotionApp
             btnAdd = new System.Windows.Forms.Button();
             btnAddQueue = new System.Windows.Forms.Button();
             btnBrew = new System.Windows.Forms.Button();
+            cmbRecipeFilter = new System.Windows.Forms.ComboBox();
+            cmbInventoryFilter = new System.Windows.Forms.ComboBox();
             listBrewRecipes = new System.Windows.Forms.ListBox();
             numAnimal = new System.Windows.Forms.NumericUpDown();
             numBerry = new System.Windows.Forms.NumericUpDown();


### PR DESCRIPTION
## Summary
- instantiate the recipe and inventory filter combo boxes before using them

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet build PotionApp.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop missing)*

------
https://chatgpt.com/codex/tasks/task_e_684700e83a5c8329bffa753d076a710e