### PR TITLE
Add water container creation prompt

### DIFF
--- a/Form1.Designer.cs
+++ b/Form1.Designer.cs
@@ -34,6 +34,7 @@ namespace PotionApp
         private VerticalProgressBar barWater;
         private System.Windows.Forms.Label lblWater;
         private System.Windows.Forms.Button btnFillWater;
+        private System.Windows.Forms.Button btnAddWater;
         private System.Windows.Forms.ListBox listWaterContainers;
         private System.Windows.Forms.RichTextBox rtbTotals;
         private System.Windows.Forms.Label lblRecipeColumns;
@@ -82,6 +83,7 @@ namespace PotionApp
             barWater = new VerticalProgressBar();
             lblWater = new System.Windows.Forms.Label();
             btnFillWater = new System.Windows.Forms.Button();
+            btnAddWater = new System.Windows.Forms.Button();
             listWaterContainers = new System.Windows.Forms.ListBox();
             txtHelp = new System.Windows.Forms.TextBox();
             lblRecipeColumns = new System.Windows.Forms.Label();
@@ -186,6 +188,7 @@ namespace PotionApp
             tabBrew.Controls.Add(barWater);
             tabBrew.Controls.Add(lblWater);
             tabBrew.Controls.Add(btnFillWater);
+            tabBrew.Controls.Add(btnAddWater);
             tabBrew.Controls.Add(listWaterContainers);
             tabBrew.Location = new System.Drawing.Point(4, 24);
             tabBrew.Name = "tabBrew";
@@ -292,6 +295,15 @@ namespace PotionApp
             btnFillWater.Text = "Fill";
             btnFillWater.UseVisualStyleBackColor = true;
             btnFillWater.Click += btnFillWater_Click;
+            //
+            // btnAddWater
+            //
+            btnAddWater.Location = new System.Drawing.Point(1066, 53);
+            btnAddWater.Name = "btnAddWater";
+            btnAddWater.Size = new System.Drawing.Size(92, 23);
+            btnAddWater.Text = "Add";
+            btnAddWater.UseVisualStyleBackColor = true;
+            btnAddWater.Click += btnAddWater_Click;
             //
             // listWaterContainers
             //

--- a/Form1.cs
+++ b/Form1.cs
@@ -215,6 +215,16 @@ namespace PotionApp
             RefreshWater();
         }
 
+        private void btnAddWater_Click(object? sender, EventArgs e)
+        {
+            var wc = WaterContainerPrompt.ShowDialog("Add Water Container");
+            if (wc != null)
+            {
+                waterContainers.Add(wc);
+                RefreshWater();
+            }
+        }
+
         private void listInventory_DoubleClick(object? sender, EventArgs e)
         {
             if (listInventory.SelectedItem is not string item) return;

--- a/WaterContainerPrompt.cs
+++ b/WaterContainerPrompt.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace PotionApp
+{
+    public static class WaterContainerPrompt
+    {
+        public static WaterContainer? ShowDialog(string caption)
+        {
+            using var form = new Form();
+            form.Text = caption;
+            form.FormBorderStyle = FormBorderStyle.FixedDialog;
+            form.StartPosition = FormStartPosition.CenterParent;
+            form.MinimizeBox = false;
+            form.MaximizeBox = false;
+            form.ClientSize = new Size(400, 170);
+
+            var lblName = new Label { AutoSize = true, Text = "Name:", Location = new Point(9, 9) };
+            var txtName = new TextBox { Location = new Point(120, 6), Width = 250 };
+
+            var lblCap = new Label { AutoSize = true, Text = "Capacity (mL):", Location = new Point(9, 45) };
+            var txtCap = new TextBox { Location = new Point(120, 42), Width = 100 };
+
+            var lblAmt = new Label { AutoSize = true, Text = "Current Amount:", Location = new Point(9, 81) };
+            var txtAmt = new TextBox { Location = new Point(120, 78), Width = 100 };
+
+            var btnOk = new Button { Text = "OK", DialogResult = DialogResult.OK, Location = new Point(313, 129) };
+            var btnCancel = new Button { Text = "Cancel", DialogResult = DialogResult.Cancel, Location = new Point(232, 129) };
+
+            form.Controls.AddRange(new Control[] { lblName, txtName, lblCap, txtCap, lblAmt, txtAmt, btnCancel, btnOk });
+            form.AcceptButton = btnOk;
+            form.CancelButton = btnCancel;
+
+            if (form.ShowDialog() != DialogResult.OK)
+                return null;
+
+            if (!int.TryParse(txtCap.Text.Trim(), out int cap) || cap <= 0)
+            {
+                MessageBox.Show("Invalid capacity", caption, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return null;
+            }
+            if (!int.TryParse(txtAmt.Text.Trim(), out int amt) || amt < 0)
+            {
+                MessageBox.Show("Invalid amount", caption, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return null;
+            }
+            amt = Math.Min(amt, cap);
+            return new WaterContainer { Name = txtName.Text.Trim(), Capacity = cap, Amount = amt };
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `WaterContainerPrompt` helper to capture name, capacity and amount
- wire up new Add Water button in the brewing tab
- hook up handler to insert new container from prompt

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858b67784b48329b2b6c7ae2ba705c0