### PR TITLE
Fix overlapping UI controls

### DIFF
--- a/Form1.Designer.cs
+++ b/Form1.Designer.cs
@@ -228,7 +228,7 @@ namespace PotionApp
             //
             listQueue.FormattingEnabled = true;
             listQueue.ItemHeight = 15;
-            listQueue.Location = new System.Drawing.Point(406, 199);
+            listQueue.Location = new System.Drawing.Point(406, 220);
             listQueue.Name = "listQueue";
             listQueue.Size = new System.Drawing.Size(480, 243);
             listQueue.Font = new System.Drawing.Font("Consolas", 9F);
@@ -237,7 +237,7 @@ namespace PotionApp
             // lblQueueColumns
             //
             lblQueueColumns.AutoSize = true;
-            lblQueueColumns.Location = new System.Drawing.Point(406, 180);
+            lblQueueColumns.Location = new System.Drawing.Point(406, 201);
             lblQueueColumns.Name = "lblQueueColumns";
             lblQueueColumns.Size = new System.Drawing.Size(0, 15);
             lblQueueColumns.TabIndex = 9;
@@ -245,7 +245,7 @@ namespace PotionApp
             //
             // btnBrew
             //
-            btnBrew.Location = new System.Drawing.Point(892, 199);
+            btnBrew.Location = new System.Drawing.Point(892, 220);
             btnBrew.Name = "btnBrew";
             btnBrew.Size = new System.Drawing.Size(75, 23);
             btnBrew.Text = "Brew All";
@@ -254,7 +254,7 @@ namespace PotionApp
             //
             // btnClearQueue
             //
-            btnClearQueue.Location = new System.Drawing.Point(973, 199);
+            btnClearQueue.Location = new System.Drawing.Point(973, 220);
             btnClearQueue.Name = "btnClearQueue";
             btnClearQueue.Size = new System.Drawing.Size(70, 23);
             btnClearQueue.Text = "Clear";

--- a/Form1.cs
+++ b/Form1.cs
@@ -23,7 +23,7 @@ namespace PotionApp
 
         // Horizontal offset used when laying out controls on the Brewing tab
         // Moved left slightly so controls do not overlap the water UI
-        private const int BrewOffsetX = 500;
+        private const int BrewOffsetX = 480;
 
         private readonly List<WaterContainer> waterContainers = new();
         private readonly ContextMenuStrip waterMenu = new();
@@ -504,15 +504,10 @@ namespace PotionApp
             string[] labels = ingredientNames;
             for (int i = 0; i < nums.Length; i++)
             {
-                int row = i / 4;
-                int col = i % 4;
+                int row = i / 3;
+                int col = i % 3;
                 int x = BrewOffsetX + 6 + col * 140;
                 int y = 6 + row * 80;
-                if (i == nums.Length - 1)
-                {
-                    x = BrewOffsetX + 6 + 3 * 140;
-                    y -= 20;
-                }
 
                 Label lbl = new Label
                 {


### PR DESCRIPTION
## Summary
- bump BrewOffsetX constant
- place numeric controls in three columns instead of four
- move queue-related controls down slightly to keep spacing around ingredients

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858bc5f7cec83299237c9679c1aaf60