### PR TITLE
Fix Brew tab layout

### DIFF
--- a/Form1.Designer.cs
+++ b/Form1.Designer.cs
@@ -177,31 +177,34 @@ namespace PotionApp
             //
             // tabBrew
             //
+            grpIngredients.Controls.Add(numAnimal);
+            grpIngredients.Controls.Add(numBerry);
+            grpIngredients.Controls.Add(numFungi);
+            grpIngredients.Controls.Add(numHerb);
+            grpIngredients.Controls.Add(numMagic);
+            grpIngredients.Controls.Add(numMineral);
+            grpIngredients.Controls.Add(numRoot);
+            grpIngredients.Controls.Add(numSolution);
+            grpIngredients.Controls.Add(numBottles);
+
+            grpWater.Controls.Add(barWater);
+            grpWater.Controls.Add(lblWater);
+            grpWater.Controls.Add(btnFillWater);
+            grpWater.Controls.Add(btnAddWater);
+            grpWater.Controls.Add(listWaterContainers);
+
+            grpQueue.Controls.Add(lblQueueColumns);
+            grpQueue.Controls.Add(listQueue);
+            grpQueue.Controls.Add(btnBrew);
+            grpQueue.Controls.Add(btnClearQueue);
+            grpQueue.Controls.Add(rtbTotals);
+
             tabBrew.Controls.Add(grpWater);
             tabBrew.Controls.Add(grpQueue);
             tabBrew.Controls.Add(grpIngredients);
             tabBrew.Controls.Add(listBrewRecipes);
             tabBrew.Controls.Add(cmbBrewFilter);
             tabBrew.Controls.Add(btnAddQueue);
-            tabBrew.Controls.Add(lblQueueColumns);
-            tabBrew.Controls.Add(listQueue);
-            tabBrew.Controls.Add(btnBrew);
-            tabBrew.Controls.Add(btnClearQueue);
-            tabBrew.Controls.Add(rtbTotals);
-            tabBrew.Controls.Add(numAnimal);
-            tabBrew.Controls.Add(numBerry);
-            tabBrew.Controls.Add(numFungi);
-            tabBrew.Controls.Add(numHerb);
-            tabBrew.Controls.Add(numMagic);
-            tabBrew.Controls.Add(numMineral);
-            tabBrew.Controls.Add(numRoot);
-            tabBrew.Controls.Add(numSolution);
-            tabBrew.Controls.Add(numBottles);
-            tabBrew.Controls.Add(barWater);
-            tabBrew.Controls.Add(lblWater);
-            tabBrew.Controls.Add(btnFillWater);
-            tabBrew.Controls.Add(btnAddWater);
-            tabBrew.Controls.Add(listWaterContainers);
             tabBrew.Location = new System.Drawing.Point(4, 24);
             tabBrew.Name = "tabBrew";
             tabBrew.Padding = new System.Windows.Forms.Padding(3);

--- a/Form1.cs
+++ b/Form1.cs
@@ -515,7 +515,7 @@ namespace PotionApp
                     Location = new System.Drawing.Point(x, y),
                     AutoSize = true
                 };
-                tabBrew.Controls.Add(lbl);
+                grpIngredients.Controls.Add(lbl);
 
                 Button btnMinus = new Button
                 {
@@ -525,13 +525,13 @@ namespace PotionApp
                     Tag = nums[i]
                 };
                 btnMinus.Click += adjustAmount_Click;
-                tabBrew.Controls.Add(btnMinus);
+                grpIngredients.Controls.Add(btnMinus);
 
                 nums[i].Location = new System.Drawing.Point(x + 24, y + 20);
                 nums[i].Maximum = decimal.MaxValue;
                 nums[i].Size = new System.Drawing.Size(60, 23);
                 nums[i].ValueChanged += (s, e) => RefreshTotals();
-                tabBrew.Controls.Add(nums[i]);
+                grpIngredients.Controls.Add(nums[i]);
 
                 Button btnPlus = new Button
                 {
@@ -541,7 +541,7 @@ namespace PotionApp
                     Tag = nums[i]
                 };
                 btnPlus.Click += adjustAmount_Click;
-                tabBrew.Controls.Add(btnPlus);
+                grpIngredients.Controls.Add(btnPlus);
             }
         }
 


### PR DESCRIPTION
## Summary
- move ingredient, queue, and water controls inside their group boxes
- update `SetupIngredientControls` to add controls to the Ingredients group

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_685902ee27048329a9dadf806db44346